### PR TITLE
Add runtime error if client secret has expired

### DIFF
--- a/fastapimsal/auth_routes.py
+++ b/fastapimsal/auth_routes.py
@@ -81,6 +81,8 @@ def create_auth_router(
             request.session.pop("flow", None)
 
             # Just store the oid (https://docs.microsoft.com/en-us/azure/active-directory/develop/id-tokens) in a signed cookie
+            if result.get("error"):
+                raise RuntimeError(f"{result.get('error')}: {result.get('error_description')}")
             oid = result.get("id_token_claims").get("oid")
             await f_save_cache(oid, cache)
             request.session["user"] = oid


### PR DESCRIPTION
## Summary

If the client secret expires (or some other error occurs), an informative error is not given. This PR adds a runtime error that displays any errors. 
